### PR TITLE
Fix database initialization hook for Flask 3

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,8 +89,8 @@ with app.app_context():
     _create_tables_if_missing()
 
 
-@app.before_first_request
-def ensure_tables_on_request():
+@app.before_serving
+def ensure_tables_on_serve():
     _create_tables_if_missing()
 
 # ---------- ROUTES ----------


### PR DESCRIPTION
## Summary
- replace the deprecated `before_first_request` hook with `before_serving` so the database tables are created under Flask 3

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913526ab248832f9c87111c4133241a)